### PR TITLE
Handle multi-line footnotes

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -2209,7 +2209,7 @@ export default class HighlightCommentsPlugin extends Plugin {
 
     extractFootnotes(content: string): Map<string, string> {
         const footnoteMap = new Map<string, string>();
-        const footnoteRegex = /^\[\^(\w+)\]:\s*(.+)$/gm;
+        const footnoteRegex = /^\[\^(\w+)\]:\s*(.+(?:(?:\n+\s*$)*\n(?:  |\t).+))$/gm;
         let match;
         
         while ((match = footnoteRegex.exec(content)) !== null) {

--- a/main.ts
+++ b/main.ts
@@ -2209,7 +2209,7 @@ export default class HighlightCommentsPlugin extends Plugin {
 
     extractFootnotes(content: string): Map<string, string> {
         const footnoteMap = new Map<string, string>();
-        const footnoteRegex = /^\[\^(\w+)\]:\s*(.+(?:(?:\n+\s*$)*\n(?:  |\t).+))$/gm;
+        const footnoteRegex = /^\[\^(\w+)\]:\s*(.+(?:(?:\n+\s*$)*\n(?:  |\t).+)*)$/gm;
         let match;
         
         while ((match = footnoteRegex.exec(content)) !== null) {


### PR DESCRIPTION
Currently, sidebar-highlights only shows the first line of a multi-line footnote in the sidebar. This pull request updates the regexp that is used for extracting footnote content to correctly match multiline footnotes.