### PR TITLE
Fix highlights containing inline code

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -2751,13 +2751,14 @@ export default class HighlightCommentsPlugin extends Plugin {
     }
 
     /**
-     * Check if a range overlaps with any of the provided code block ranges
-     * Returns true if the range is fully inside, partially overlaps, or spans across a code block
+     * Check if a range is fully contained by any of the provided code block ranges.
+     *
+     * A highlight may legitimately contain inline code, so partial overlap must
+     * not exclude the entire highlight. Only ranges fully inside code are ignored.
      */
     private isInsideCodeBlock(start: number, end: number, codeBlockRanges: Array<{start: number, end: number}>): boolean {
         return codeBlockRanges.some(range => {
-            // Check for any overlap: ranges overlap if start < range.end AND end > range.start
-            return start < range.end && end > range.start;
+            return start >= range.start && end <= range.end;
         });
     }
 

--- a/src/utils/highlight-detection.test.ts
+++ b/src/utils/highlight-detection.test.ts
@@ -6,6 +6,30 @@
 export {};
 
 describe('Highlight Detection Patterns', () => {
+    describe('Code range filtering', () => {
+        const isInsideCodeBlock = (
+            start: number,
+            end: number,
+            codeBlockRanges: Array<{ start: number; end: number }>
+        ) => codeBlockRanges.some(range => start >= range.start && end <= range.end);
+
+        it('does not exclude a highlight that contains an inline code span', () => {
+            const highlightStart = 0;
+            const highlightEnd = 30;
+            const inlineCodeRange = [{ start: 8, end: 18 }];
+
+            expect(isInsideCodeBlock(highlightStart, highlightEnd, inlineCodeRange)).toBe(false);
+        });
+
+        it('continues to exclude a highlight fully contained in a code span', () => {
+            const highlightStart = 10;
+            const highlightEnd = 16;
+            const inlineCodeRange = [{ start: 8, end: 18 }];
+
+            expect(isInsideCodeBlock(highlightStart, highlightEnd, inlineCodeRange)).toBe(true);
+        });
+    });
+
     describe('Markdown highlight regex', () => {
         const markdownHighlightRegex = /==([^=\n](?:[^=\n]|=[^=\n])*?[^=\n])==/g;
 


### PR DESCRIPTION
## Summary

Fixes an issue where a Sidebar Highlights entry was omitted when the highlighted text contained inline code wrapped in backticks.

## Root cause

`isInsideCodeBlock` treated any overlap between a highlight range and an inline-code range as a code block match. Therefore a valid highlight such as `==text with \`inline code\`==^[comment]` was filtered out.

## Changes

- Only treat a highlight as code when it is fully contained within a code range.
- Keep filtering highlights that are actually inside code spans/blocks.
- Add regression tests for both cases.

## Verification

- `npm test -- --runInBand` — 9 suites, 290 tests passed
- `npm run build` — passed

Related reports: #102, #111