### PR TITLE
Track every open Highlights view instead of only the most recent

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -427,6 +427,10 @@ export default class HighlightCommentsPlugin extends Plugin {
             this.ribbonIconEl = null;
         }
 
+        // Drop the tracked views. Obsidian detaches the leaves it owns, but a view
+        // another plugin hosts on a detached leaf never gets that onClose.
+        this.sidebarViews.clear();
+
         // Cleanup is mostly automatic due to using registerEvent() and addCommand()
         // The sidebar view's onClose() method will handle its own cleanup
         // Obsidian automatically handles:
@@ -532,7 +536,9 @@ export default class HighlightCommentsPlugin extends Plugin {
         document.body.style.setProperty('--sh-task-font-weight', `${this.settings.taskFontWeight}`);
     }
 
-    async activateView() {
+    // Returns the leaf it revealed, so a caller that must act on exactly one
+    // panel acts on the one the user was just shown.
+    async activateView(): Promise<WorkspaceLeaf | null> {
         const { workspace } = this.app;
         let leaf: WorkspaceLeaf | null = null;
         const leaves = workspace.getLeavesOfType(VIEW_TYPE_HIGHLIGHTS);
@@ -546,8 +552,11 @@ export default class HighlightCommentsPlugin extends Plugin {
             await leaf?.setViewState({ type: VIEW_TYPE_HIGHLIGHTS, active: true });
         }
         if (leaf) {
-            void workspace.revealLeaf(leaf);
+            // Awaited: revealLeaf loads a deferred view, so leaf.view is the real
+            // panel by the time we return it rather than a deferred placeholder.
+            await workspace.revealLeaf(leaf);
         }
+        return leaf;
     }
 
     async toggleView() {
@@ -600,23 +609,6 @@ export default class HighlightCommentsPlugin extends Plugin {
         editor.replaceSelection(highlightedText);
         this.refreshSidebar();
         new Notice('Highlight created');
-    }
-
-    // The view a user-initiated command acts on. Prefers one whose leaf is
-    // really in the workspace, so a copy hosted outside the layout by another
-    // plugin is never what a command navigates or reveals.
-    private get sidebarView(): HighlightsSidebarView | null {
-        let fallback: HighlightsSidebarView | null = null;
-        const inWorkspace = this.app.workspace.getLeavesOfType(VIEW_TYPE_HIGHLIGHTS);
-        for (const view of this.sidebarViews) {
-            if (inWorkspace.includes(view.leaf)) {
-                return view;
-            }
-            if (!fallback) {
-                fallback = view;
-            }
-        }
-        return fallback;
     }
 
     // Run fn against every open panel, so they all stay in step.
@@ -1716,12 +1708,13 @@ export default class HighlightCommentsPlugin extends Plugin {
 
     // Navigate to a specific collection in the sidebar
     private async goToCollection(collectionId: string) {
-        // First, make sure the sidebar is open
-        await this.activateView();
-        
-        // Then navigate to the collection
-        if (this.sidebarView) {
-            this.sidebarView.navigateToCollection(collectionId);
+        // Navigate the panel that was actually revealed. Picking a view out of
+        // the tracked set instead could switch a panel the user is not looking
+        // at, or one another plugin hosts outside the workspace.
+        const leaf = await this.activateView();
+        const view = leaf?.view;
+        if (view instanceof HighlightsSidebarView) {
+            view.navigateToCollection(collectionId);
         }
     }
 
@@ -2494,7 +2487,20 @@ export default class HighlightCommentsPlugin extends Plugin {
      * Smart sidebar update: use targeted updates when possible, full refresh only when necessary
      */
     private smartUpdateSidebar(oldHighlights: Highlight[], newHighlights: Highlight[]): void {
-        if (this.sidebarViews.size === 0) {
+        // Panels on a tab that doesn't display highlights take no update. Decided
+        // per panel rather than once: two panels can be on different tabs, and one
+        // sitting on Tasks shouldn't hold back another on Highlights. Gathered
+        // before the diff so a layout with nothing to update stays free, and data
+        // is still updated in storage either way.
+        const targets: HighlightsSidebarView[] = [];
+        this.forEachSidebarView(view => {
+            const viewMode = view.getViewMode();
+            if (viewMode !== 'tasks' && viewMode !== 'collections') {
+                targets.push(view);
+            }
+        });
+
+        if (targets.length === 0) {
             return;
         }
 
@@ -2541,28 +2547,19 @@ export default class HighlightCommentsPlugin extends Plugin {
             }
         }
 
-        this.forEachSidebarView(view => {
-            // Skip panels on a tab that doesn't display highlights. Checked per
-            // panel rather than once: two panels can be on different tabs, and one
-            // sitting on Tasks shouldn't hold back the other. Data is still
-            // updated in storage either way.
-            const viewMode = view.getViewMode();
-            if (viewMode === 'tasks' || viewMode === 'collections') {
-                return;
-            }
-
+        for (const view of targets) {
             if (hasStructuralChanges) {
                 // New or deleted highlights - use updateContent() instead of full
                 // refresh. This avoids clearing task cache and rebuilding entire DOM
                 view.updateContent();
-                return;
+                continue;
             }
 
             // Only content changes - use targeted updates
             for (const id of changedIDs) {
                 view.updateItem(id);
             }
-        });
+        }
     }
 
 

--- a/main.ts
+++ b/main.ts
@@ -261,7 +261,13 @@ export default class HighlightCommentsPlugin extends Plugin {
     collections: Map<string, Collection> = new Map();
     collectionsManager: CollectionsManager;
     inlineFootnoteManager: InlineFootnoteManager;
-    private sidebarView: HighlightsSidebarView | null = null;
+    // Every sidebar view currently alive. Obsidian runs the registerView
+    // factory for each one it builds, and it can build more than one: a second
+    // pane, a pop-out window, or another plugin hosting the view in a detached
+    // leaf. Holding a single reference meant the newest instance replaced the
+    // previous one, so updates went to a panel the user was not looking at, and
+    // closing that instance left the reference pointing at a dead view.
+    private sidebarViews: Set<HighlightsSidebarView> = new Set();
     private ribbonIconEl: HTMLElement | null = null;
     private detectHighlightsTimeout: number | null = null;
     public selectedHighlightId: string | null = null;
@@ -305,8 +311,9 @@ export default class HighlightCommentsPlugin extends Plugin {
         this.registerView(
             VIEW_TYPE_HIGHLIGHTS,
             (leaf) => {
-                this.sidebarView = new HighlightsSidebarView(leaf, this);
-                return this.sidebarView;
+                const view = new HighlightsSidebarView(leaf, this);
+                this.sidebarViews.add(view);
+                return view;
             }
         );
 
@@ -352,9 +359,8 @@ export default class HighlightCommentsPlugin extends Plugin {
                 } else {
                     // Clear selection but preserve highlights when no file is active
                     this.selectedHighlightId = null;
-                    if (this.sidebarView) {
-                        this.sidebarView.updateContent(); // Content update instead of full refresh
-                    }
+                    // Content update instead of full refresh
+                    this.forEachSidebarView(view => view.updateContent());
                 }
             })
         );
@@ -596,10 +602,37 @@ export default class HighlightCommentsPlugin extends Plugin {
         new Notice('Highlight created');
     }
 
-    refreshSidebar() {
-        if (this.sidebarView) {
-            this.sidebarView.refresh();
+    // The view a user-initiated command acts on. Prefers one whose leaf is
+    // really in the workspace, so a copy hosted outside the layout by another
+    // plugin is never what a command navigates or reveals.
+    private get sidebarView(): HighlightsSidebarView | null {
+        let fallback: HighlightsSidebarView | null = null;
+        const inWorkspace = this.app.workspace.getLeavesOfType(VIEW_TYPE_HIGHLIGHTS);
+        for (const view of this.sidebarViews) {
+            if (inWorkspace.includes(view.leaf)) {
+                return view;
+            }
+            if (!fallback) {
+                fallback = view;
+            }
         }
+        return fallback;
+    }
+
+    // Run fn against every open panel, so they all stay in step.
+    private forEachSidebarView(fn: (view: HighlightsSidebarView) => void): void {
+        for (const view of [...this.sidebarViews]) {
+            fn(view);
+        }
+    }
+
+    // Called by a view as it closes, so a closed panel stops being tracked.
+    releaseSidebarView(view: HighlightsSidebarView): void {
+        this.sidebarViews.delete(view);
+    }
+
+    refreshSidebar() {
+        this.forEachSidebarView(view => view.refresh());
     }
 
     // Display Mode methods
@@ -646,9 +679,7 @@ export default class HighlightCommentsPlugin extends Plugin {
         await this.saveSettings();
 
         // Reset view mode to first visible tab if current tab is hidden
-        if (this.sidebarView) {
-            this.sidebarView.resetToFirstVisibleTab();
-        }
+        this.forEachSidebarView(view => view.resetToFirstVisibleTab());
 
         this.refreshSidebar();
     }
@@ -1738,9 +1769,7 @@ export default class HighlightCommentsPlugin extends Plugin {
             void this.saveSettings(); 
             
             // Update individual item instead of full refresh to preserve scroll position
-            if (this.sidebarView) {
-                this.sidebarView.updateItem(highlightId);
-            }
+            this.forEachSidebarView(view => view.updateItem(highlightId));
         }
     }
 
@@ -1764,9 +1793,8 @@ export default class HighlightCommentsPlugin extends Plugin {
         if (!this.shouldProcessFile(file)) {
             // Clear any existing highlights for this file and update content
             this.highlights.delete(file.path);
-            if (this.sidebarView) {
-                this.sidebarView.updateContent(); // Content update instead of full refresh
-            }
+            // Content update instead of full refresh
+            this.forEachSidebarView(view => view.updateContent());
             return;
         }
         
@@ -1774,9 +1802,8 @@ export default class HighlightCommentsPlugin extends Plugin {
         if (await this.isExcalidrawFile(file)) {
             // Clear any existing highlights for this file and update content
             this.highlights.delete(file.path);
-            if (this.sidebarView) {
-                this.sidebarView.updateContent(); // Content update instead of full refresh
-            }
+            // Content update instead of full refresh
+            this.forEachSidebarView(view => view.updateContent());
             return;
         }
         
@@ -1784,9 +1811,8 @@ export default class HighlightCommentsPlugin extends Plugin {
         // detectAndStoreMarkdownHighlights will call refreshSidebar if changes are detected
         this.detectAndStoreMarkdownHighlights(content, file);
         // Always update content when file changes, even if no highlights detected
-        if (this.sidebarView) {
-            this.sidebarView.updateContent(); // Content update instead of full refresh
-        }
+        // Content update instead of full refresh
+        this.forEachSidebarView(view => view.updateContent());
     }
 
     /**
@@ -2468,17 +2494,7 @@ export default class HighlightCommentsPlugin extends Plugin {
      * Smart sidebar update: use targeted updates when possible, full refresh only when necessary
      */
     private smartUpdateSidebar(oldHighlights: Highlight[], newHighlights: Highlight[]): void {
-        if (!this.sidebarView) {
-            return;
-        }
-
-        // Skip refresh if we're in a tab that doesn't display highlights
-        // Tasks and Collections tabs don't show highlights, so no need to refresh UI
-        const viewMode = this.sidebarView.getViewMode();
-
-        if (viewMode === 'tasks' || viewMode === 'collections') {
-            // Data is still updated in storage, but UI doesn't refresh
-            // This prevents unnecessary flashing when working in these tabs
+        if (this.sidebarViews.size === 0) {
             return;
         }
 
@@ -2496,12 +2512,9 @@ export default class HighlightCommentsPlugin extends Plugin {
                                    [...oldIDs].some(id => !newIDs.has(id)) ||
                                    [...newIDs].some(id => !oldIDs.has(id));
 
-        if (hasStructuralChanges) {
-            // New or deleted highlights - use updateContent() instead of full refresh
-            // This avoids clearing task cache and rebuilding entire DOM
-            this.sidebarView.updateContent();
-        } else {
-            // Only content changes - use targeted updates
+        // Work out which highlights changed once, then apply that to each panel.
+        const changedIDs: string[] = [];
+        if (!hasStructuralChanges) {
             for (const [id, newHighlight] of newByID) {
                 const oldHighlight = oldByID.get(id);
                 if (oldHighlight) {
@@ -2522,12 +2535,34 @@ export default class HighlightCommentsPlugin extends Plugin {
                     });
                     
                     if (oldJSON !== newJSON) {
-                        // This highlight changed - update just this item
-                        this.sidebarView.updateItem(id);
+                        changedIDs.push(id);
                     }
                 }
             }
         }
+
+        this.forEachSidebarView(view => {
+            // Skip panels on a tab that doesn't display highlights. Checked per
+            // panel rather than once: two panels can be on different tabs, and one
+            // sitting on Tasks shouldn't hold back the other. Data is still
+            // updated in storage either way.
+            const viewMode = view.getViewMode();
+            if (viewMode === 'tasks' || viewMode === 'collections') {
+                return;
+            }
+
+            if (hasStructuralChanges) {
+                // New or deleted highlights - use updateContent() instead of full
+                // refresh. This avoids clearing task cache and rebuilding entire DOM
+                view.updateContent();
+                return;
+            }
+
+            // Only content changes - use targeted updates
+            for (const id of changedIDs) {
+                view.updateItem(id);
+            }
+        });
     }
 
 

--- a/src/views/sidebar-view.ts
+++ b/src/views/sidebar-view.ts
@@ -1113,6 +1113,10 @@ export class HighlightsSidebarView extends ItemView {
     }
 
     async onClose() {
+        // Stop the plugin tracking this panel, so a closed view no longer
+        // receives updates and the panels still open keep receiving theirs.
+        this.plugin.releaseSidebarView(this);
+
         // Clean up dropdown manager
         this.dropdownManager.cleanup();
 


### PR DESCRIPTION
### Summary

Fixes #122.

The plugin held a single `sidebarView` reference, assigned inside the `registerView` factory. Obsidian runs that factory for every view it builds, and it can build more than one: a second pane, a pop-out window, or another plugin hosting the view in a detached leaf.

Each construction overwrote the reference, and nothing ever cleared it. So updates went to whichever view was built last while the user was looking at a different one, and closing that view left the reference pointing at a dead instance with no panel receiving anything.

### What changed

- `sidebarView` becomes `sidebarViews`, a `Set` of the views that are currently alive. The factory adds to it instead of overwriting a slot.
- `onClose()` removes the view from the set, so a closed panel stops being tracked and can no longer starve the panels still open.
- Content updates (`refreshSidebar`, `updateContent`, `updateItem`, `resetToFirstVisibleTab`) are broadcast to every open panel through a small `forEachSidebarView` helper.
- `sidebarView` survives as a private getter for the things that should act on exactly one view (`goToCollection`). It prefers a view whose leaf is actually in the workspace, so a copy hosted outside the layout by another plugin is never what a user-invoked command navigates or reveals.
- The Tasks/Collections skip in `smartUpdateSidebar` is now decided per panel instead of once. Two panels can sit on different tabs, and one on Tasks should not hold back another on Highlights. The diff itself is still computed once.

No behaviour change when a single panel is open, which is the common case.

### Testing

- `npx tsc -noEmit -skipLibCheck` clean
- `npm test` — 532 tests across 20 suites pass
- `npm run build` succeeds
- `npx eslint .` reports exactly the same problems as `main` (141 errors / 16 warnings, all pre-existing); this change adds none

No unit test accompanies this. `jest.config.js` roots tests at `src/`, `main.ts` sits at the repo root, and there is no `obsidian` mock, so the plugin class is not reachable from the current test setup. Verified manually with the two-panel reproduction from the issue: a sidebar panel and a pop-out panel now both update live, and closing either leaves the other working.
